### PR TITLE
Bump openapi-generator to 4.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ allprojects {
 }
 
 subprojects {
-    version = "${version}.$buildNumber"
+    version = "${openapiGeneratorVersion}-p${buildNumber}"
 
     apply plugin: 'java'
     apply plugin: 'kotlin'

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,11 +5,11 @@ javaVersion = 1.8
 
 kotlinVersion = 1.2.41
 
-version = 4.0
+openapiGeneratorVersion=4.3.0
 
+# Plugin revision, appended to OpenAPI Generator version as -pX
 buildNumber = 0
 
 downloadIdeaSources = false
 
-openapiGeneratorVersion=4.2.3
 slf4jVersion=1.7.12

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -17,7 +17,7 @@
 <idea-plugin>
   <id>main.kotlin.com.jimschubert.intellij.swaggercodegen</id>
   <name>OpenAPI Generator</name>
-  <version>4.0.0</version>
+  <version>4.3.0-p0</version>
   <vendor email="james.schubert@gmail.com" url="https://jimschubert.us">Jim Schubert</vendor>
 
   <description><![CDATA[
@@ -34,6 +34,13 @@
 
   <change-notes><![CDATA[
       <dl>
+        <dt><a href="https://github.com/jimschubert/intellij-openapi-generator/tree/v4.3.0-p0">4.3.0-p0</a></dt>
+        <dd>
+          <ul>
+            <li>Bump OpenAPI Generator version to 4.3.0</li>
+            <li>Skips plugin versions 4.1.0-4.2.0 to align with OpenAPI Generator versioning, appends semantic plugin revision</li>
+          </ul>
+        </dd>
         <dt><a href="https://github.com/jimschubert/intellij-openapi-generator/tree/v4.0.0">4.0.0</a></dt>
         <dd>
           <ul>


### PR DESCRIPTION
This also bumps the plugin version to track openapi-generator version. A
-pX suffix is added for semnantic versioning which allows tracking
revesions of the plugin against the "main line" openapi-generator.